### PR TITLE
"new hub" link (has a bug)

### DIFF
--- a/_includes/hubs_grid.html
+++ b/_includes/hubs_grid.html
@@ -32,7 +32,7 @@
       </div>
 	{% endfor %}
       <div class="col-md-4 col-sm-6 hubs-item">
-        <a class="hubs-link" data-toggle="modal" target="_blank" href="https://github.com/ASKnetCommunity/ASKnet.Community/issues/new?assignees=&labels=content-submit%2Cnew-hub&template=new-hub.yml&title=Add+Hub%3A+">
+        <a class="hubs-link" target="_blank" data-toggle="modal" href="https://github.com/ASKnetCommunity/ASKnet.Community/issues/new?assignees=&labels=content-submit%2Cnew-hub&template=new-hub.yml&title=Add+Hub%3A+">
           <div class="hubs-hover">
             <div class="hubs-hover-content">
               <i class="{{ site.data.style.hubs-icon | default: "fas fa-plus fa-3x" }}"></i>

--- a/_includes/hubs_grid.html
+++ b/_includes/hubs_grid.html
@@ -32,7 +32,7 @@
       </div>
 	{% endfor %}
       <div class="col-md-4 col-sm-6 hubs-item">
-        <a class="hubs-link" data-toggle="modal" href="#">
+        <a class="hubs-link" data-toggle="modal" target="_blank" href="https://github.com/ASKnetCommunity/ASKnet.Community/issues/new?assignees=&labels=content-submit%2Cnew-hub&template=new-hub.yml&title=Add+Hub%3A+">
           <div class="hubs-hover">
             <div class="hubs-hover-content">
               <i class="{{ site.data.style.hubs-icon | default: "fas fa-plus fa-3x" }}"></i>

--- a/_includes/hubs_grid.html
+++ b/_includes/hubs_grid.html
@@ -32,7 +32,7 @@
       </div>
 	{% endfor %}
       <div class="col-md-4 col-sm-6 hubs-item">
-        <a class="hubs-link" target="_blank" data-toggle="modal" href="https://github.com/ASKnetCommunity/ASKnet.Community/issues/new?assignees=&labels=content-submit%2Cnew-hub&template=new-hub.yml&title=Add+Hub%3A+">
+        <a class="hubs-link" target="_blank" href="https://github.com/ASKnetCommunity/ASKnet.Community/issues/new?assignees=&labels=content-submit%2Cnew-hub&template=new-hub.yml&title=Add+Hub%3A+">
           <div class="hubs-hover">
             <div class="hubs-hover-content">
               <i class="{{ site.data.style.hubs-icon | default: "fas fa-plus fa-3x" }}"></i>


### PR DESCRIPTION
created the issue form and added the link. But when I click, it somehow doesnt open. maybe the bootstrap classes are wrong (because all the other hub links don't load a new page, but just an overlay). Please fix it :smile: 